### PR TITLE
Implemented a SCRAM server, with testing

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,19 +1,16 @@
 use std::borrow::Cow;
 use std::io;
+
 use data_encoding::base64;
 use rand::distributions::IndependentSample;
 use rand::distributions::range::Range;
 use rand::os::OsRng;
 use rand::Rng;
-use ring::digest::{digest, SHA256, Digest};
-use ring::hmac::{SigningKey, SigningContext, sign};
-use ring::pbkdf2::{HMAC_SHA256, derive};
-use error::{Error, Kind, Field};
+use ring::digest::Digest;
 
-/// The length of the client nonce in characters/bytes.
-const NONCE_LENGTH: usize = 24;
-/// The length of a SHA-256 hash in bytes.
-const SHA256_LEN: usize = 32;
+use utils::{hash_password, find_proofs};
+use error::{Error, Kind, Field};
+use ::{NONCE_LENGTH, SHA256_LEN};
 
 /// Parses a `server_first_message` returning a (none, salt, iterations) tuple if successful.
 fn parse_server_first(data: &str) -> Result<(&str, Vec<u8>, u16), Error> {
@@ -174,48 +171,20 @@ impl<'a> ServerFirst<'a> {
     /// * Error::Protocol
     /// * Error::UnsupportedExtension
     pub fn handle_server_first(self, server_first: &str) -> Result<ClientFinal, Error> {
-        fn sign_slice(key: &SigningKey, slice: &[&[u8]]) -> Digest {
-            let mut signature_context = SigningContext::with_key(key);
-            for item in slice {
-                signature_context.update(item);
-            }
-            signature_context.sign()
-        }
 
         let (nonce, salt, iterations) = try!(parse_server_first(server_first));
         if !nonce.starts_with(&self.client_nonce) {
             return Err(Error::Protocol(Kind::InvalidNonce));
         }
 
-        let client_final_without_proof = format!("c={},r={}",
-                                                 base64::encode(self.gs2header.as_bytes()),
-                                                 nonce);
-        let auth_message = [self.client_first_bare.as_bytes(),
-                            b",",
-                            server_first.as_bytes(),
-                            b",",
-                            client_final_without_proof.as_bytes()];
+        let salted_password = hash_password(self.password, iterations, &salt);
 
-        let mut salted_password = [0u8; SHA256_LEN];
-        derive(&HMAC_SHA256,
-               iterations as usize,
-               &salt,
-               self.password.as_bytes(),
-               &mut salted_password);
-        let salted_password_signing_key = SigningKey::new(&SHA256, &salted_password);
-        let client_key = sign(&salted_password_signing_key, b"Client Key");
-        let server_key = sign(&salted_password_signing_key, b"Server Key");
-        let stored_key = digest(&SHA256, client_key.as_ref());
-        let stored_key_signing_key = SigningKey::new(&SHA256, stored_key.as_ref());
-        let client_signature = sign_slice(&stored_key_signing_key, &auth_message);
-        let server_signature_signing_key = SigningKey::new(&SHA256, server_key.as_ref());
-        let server_signature = sign_slice(&server_signature_signing_key, &auth_message);
-        let mut client_proof = [0u8; SHA256_LEN];
-        let xor_iter =
-            client_key.as_ref().iter().zip(client_signature.as_ref()).map(|(k, s)| k ^ s);
-        for (p, x) in client_proof.iter_mut().zip(xor_iter) {
-            *p = x
-        }
+        let (client_proof, server_signature): ([u8; SHA256_LEN], Digest) =
+            find_proofs(&self.gs2header,
+                        &self.client_first_bare.into(),
+                        &server_first.into(),
+                        &salted_password,
+                        nonce);
 
         let client_final = format!("c={},r={},p={}",
                                    base64::encode(self.gs2header.as_bytes()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::{error, fmt};
 
 /// The SCRAM mechanism error cases.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// A message wasn't formatted as required. `Kind` contains further information.
     ///
@@ -14,10 +14,12 @@ pub enum Error {
     InvalidServer,
     /// The server rejected the authentication request. `String` contains a message from the server.
     Authentication(String),
+    /// The username supplied was not valid
+    InvalidUser(String),
 }
 
 /// The kinds of protocol errors.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Kind {
     /// The server responded with a nonce that doesn't start with our nonce.
     InvalidNonce,
@@ -28,7 +30,7 @@ pub enum Kind {
 }
 
 /// The fields used in the exchanged messages.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Field {
     /// Nonce
     Nonce,
@@ -38,6 +40,16 @@ pub enum Field {
     Iterations,
     /// Verify or Error
     VerifyOrError,
+    /// Channel Binding
+    ChannelBinding,
+    /// Authtorization ID
+    Authzid,
+    /// Authcid
+    Authcid,
+    /// GS2Header
+    GS2Header,
+    /// Client Proof
+    Proof
 }
 
 impl fmt::Display for Error {
@@ -50,6 +62,7 @@ impl fmt::Display for Error {
             Protocol(ExpectedField(ref field)) => write!(fmt, "Expected field {:?}", field),
             UnsupportedExtension => write!(fmt, "Unsupported extension"),
             InvalidServer => write!(fmt, "Server failed validation"),
+            InvalidUser(ref username) => write!(fmt, "Invalid user: '{}'", username),
             Authentication(ref msg) => write!(fmt, "authentication error {}", msg),
         }
     }
@@ -65,6 +78,7 @@ impl error::Error for Error {
             Protocol(ExpectedField(_)) => "Expected field",
             UnsupportedExtension => "Unsupported extension",
             InvalidServer => "Server failed validation",
+            InvalidUser(_) => "Invalid user",
             Authentication(_) => "Unspecified error",
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,26 +5,27 @@
 //!
 //! # Usage
 //!
+//! ## Client
 //! A typical usage scenario is shown below. For a detailed explanation of the methods please
 //! consider their documentation. In productive code you should replace the unwrapping by proper
 //! error handling.
 //!
 //! At first the user and the password must be supplied using either of the methods
-//! [`ClientFirst::new`](struct.ClientFirst.html#method.new) or
-//! [`ClientFirst::with_rng`](struct.ClientFirst.html#method.with_rng). These methods return a SCRAM
+//! [`ClientFirst::new`](client/struct.ClientFirst.html#method.new) or
+//! [`ClientFirst::with_rng`](client/struct.ClientFirst.html#method.with_rng). These methods return a SCRAM
 //! state you can use to compute the first client message.
 //!
 //! The server and the client exchange four messages using the SCRAM mechanism. There is a rust type
 //! for each one of them. Calling the methods
-//! [`client_first`](struct.ClientFirst.html#method.client_first),
-//! [`handle_server_first`](struct.ServerFirst.html#method.handle_server_first),
-//! [`client_final`](struct.ClientFinal.html#method.client_final) and
-//! [`handle_server_final`](struct.ServerFinal.html#method.handle_server_final) on the different
+//! [`client_first`](client/struct.ClientFirst.html#method.client_first),
+//! [`handle_server_first`](client/struct.ServerFirst.html#method.handle_server_first),
+//! [`client_final`](client/struct.ClientFinal.html#method.client_final) and
+//! [`handle_server_final`](client/struct.ServerFinal.html#method.handle_server_final) on the different
 //! types advances the SCRAM handshake step by step. Computing client messages never fails but
 //! processing server messages can result in failure.
 //!
 //! ``` rust,no_run
-//! use scram::ClientFirst;
+//! use scram::client::ClientFirst;
 //!
 //! // This function represents your I/O implementation.
 //! # #[allow(unused_variables)]
@@ -55,13 +56,90 @@
 //! // wasn't successful.
 //! let () = scram.handle_server_final(&server_final).unwrap();
 //! ```
-
+//!
+//! ## Server
+//!
+//! The server is created to respond to incoming challenges from a client.  A typical usage pattern,
+//! with a default provider is shown below.  In production, you would implement an AuthenticationProvider
+//! that could look up user credentials based on a username
+//!
+//! The server and the client exchange four messages using the SCRAM mechanism. There is a rust type
+//! for each one of them. Calling the methods
+//! [`handle_client_first`](server/struct.ScramServer.html#method.handle_client_first),
+//! [`server_first`](server/struct.ServerFirst.html#method.server_first),
+//! [`handle_client_final`](server/struct.ClientFinal.html#method.handle_client_final) and
+//! [`server_final`](server/struct.ServerFinal.html#method.server_final) on the different
+//! types advances the SCRAM handshake step by step. Computing server messages never fails (unless
+//! the source of randomness for the nonce fails), but processing client messages can result in
+//! failure.
+//!
+//! The final step will not return an error if authentication failed, but will return an
+//! [`AuthenticationStatus`](server/enum.AuthenticationStatus/html) which you can use to determine
+//! if authentication was successful or not.
+//!
+//! ```rust,no_run
+//! use scram::server::{ScramServer, AuthenticationStatus, AuthenticationProvider, PasswordInfo};
+//!
+//! // Create a dummy authentication provider
+//! struct ExampleProvider;
+//! impl AuthenticationProvider for ExampleProvider {
+//!     // Here you would look up password information for the the given username
+//!     fn get_password_for(&self, username: &str) -> Option<PasswordInfo> {
+//!        unimplemented!()
+//!     }
+//!
+//! }
+//! // These functions represent your I/O implementation.
+//! # #[allow(unused_variables)]
+//! fn receive() -> String {
+//!     unimplemented!()
+//! }
+//! # #[allow(unused_variables)]
+//! fn send(message: &str) {
+//!     unimplemented!()
+//! }
+//!
+//! // Create a new ScramServer using the example authenication provider
+//! let scram_server = ScramServer::new(ExampleProvider{});
+//!
+//! // Receive a message from the client
+//! let client_first = receive();
+//!
+//! // Create a SCRAM state from the client's first message
+//! let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+//! // Craft a response to the client's message and advance the SCRAM state
+//! // We could use our own source of randomness here, with `server_first_with_rng()`
+//! let (scram_server, server_first) = scram_server.server_first().unwrap();
+//! // Send our message to the client and read the response
+//! send(&server_first);
+//! let client_final = receive();
+//!
+//! // Process the client's challenge and re-assign the SCRAM state.  This could fail if the
+//! // message was poorly formatted
+//! let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+//!
+//! // Prepare the final message and get the authentication status
+//! let(status, server_final) = scram_server.server_final();
+//! // Send our final message to the client
+//! send(&server_final);
+//!
+//! // Check if the client successfully authenticated
+//! assert_eq!(status, AuthenticationStatus::Authenticated);
+//! ```
 extern crate data_encoding;
 extern crate rand;
 extern crate ring;
 
+/// The length of the client nonce in characters/bytes.
+const NONCE_LENGTH: usize = 24;
+/// The length of a SHA-256 hash in bytes.
+const SHA256_LEN: usize = 32;
+
+#[macro_use]
+mod utils;
 mod error;
-mod client;
+pub mod client;
+pub mod server;
 
 pub use error::{Error, Kind, Field};
-pub use client::{ClientFirst, ServerFirst, ClientFinal, ServerFinal};
+pub use utils::hash_password;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,395 @@
+use std::borrow::Cow;
+use std::io;
+
+use data_encoding::base64;
+use rand::distributions::IndependentSample;
+use rand::distributions::range::Range;
+use rand::os::OsRng;
+use rand::Rng;
+use ring::digest::Digest;
+
+use error::{Error, Kind, Field};
+use utils::find_proofs;
+use ::{NONCE_LENGTH, SHA256_LEN};
+
+/// Responds to client authentication challenges.
+/// The entrypoint for the SCRAM server side implementation
+pub struct ScramServer<P: AuthenticationProvider> {
+    /// The [authentication provider](trait.AuthenticationProvider.html) that will find passwords
+    /// and check authorization
+    provider: P
+
+}
+
+/// Contains information about stored passwords.  In particular, it stores the password that
+/// has been salted and hashed, the salt that was used, and the number of iterations of the hashing
+/// algorithm
+pub struct PasswordInfo {
+    hashed_password: Vec<u8>,
+    salt: Vec<u8>,
+    iterations: u16
+}
+
+/// The status of authenication after the final client message has been received by the server
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum AuthenticationStatus {
+    /// The client has correctly authenticated, and has been authorized
+    Authenticated,
+    /// The client was not correctly authenticated, meaning they supplied an incorrect password
+    NotAuthenticated,
+    /// The client authenticated correctly, but was not authorized for the alternate user
+    /// they requested
+    NotAuthorized
+}
+
+impl PasswordInfo {
+    /// Create a new PasswordInfo from the given information.  The password is assumed to have
+    /// already been hashed using the given salt and iterations.
+    pub fn new(hashed_password: Vec<u8>, iterations: u16, salt: Vec<u8>) -> Self {
+        PasswordInfo {
+            hashed_password: hashed_password,
+            iterations: iterations,
+            salt: salt        }
+
+    }
+}
+
+/// An ``AuthenticationProvider` looks up password information for a given user, and also
+/// checks if a user is authorized to act on another user's behalf.  The authorization component
+/// is optional, and if not implemented will simply allow users to act on their own behalf, and no
+/// one else's.
+///
+/// To ensure the password is hashed correctly, cleartext passwords can be hased using the
+/// [`hash_password()`](../index.html#method.hash_password) function provided in the crate root.
+pub trait AuthenticationProvider {
+    /// Gets the [`PasswordInfo`](struct.PasswordInfo.html) for the given user.
+    fn get_password_for(&self, username: &str) -> Option<PasswordInfo>;
+
+    /// Checks to see if the user given by `authcid` is authorized to act as the user given
+    /// by `authzid.`  Implementors do not need to implement this method.  The default
+    /// implementation just checks if the two are equal
+    fn authorize(&self, authcid: &str, authzid: &str) -> bool {
+        authcid == authzid
+    }
+}
+
+
+/// Parses a client's first message by splitting it on commas and analyzing each part
+/// Gives an error if the data was malformed in any way
+fn parse_client_first(data: &str) -> Result<(&str, Option<&str>, &str), Error> {
+    let mut parts = data.split(',');
+
+    // Channel binding
+    if let Some(part) = parts.next() {
+        if let Some(cb) = part.chars().next() {
+            if cb == 'p' {
+                return Err(Error::UnsupportedExtension);
+            }
+            if cb != 'n' && cb != 'y' || part.len() > 1 {
+                return Err(Error::Protocol(Kind::InvalidField(Field::ChannelBinding)));
+            }
+        } else {
+            return Err(Error::Protocol(Kind::ExpectedField(Field::ChannelBinding)));
+        }
+    } else {
+        return Err(Error::Protocol(Kind::ExpectedField(Field::ChannelBinding)));
+    }
+
+    // Authzid
+    let authzid = if let Some(part) = parts.next() {
+        if part.len() == 0 {
+            None
+        } else if part.len() < 2 {
+            return Err(Error::Protocol(Kind::ExpectedField(Field::Authzid)));
+        } else if &part.as_bytes()[..2] == b"a=" {
+            Some(&part[2..])
+        } else {
+            return Err(Error::Protocol(Kind::ExpectedField(Field::Authzid)));
+        }
+    } else {
+        return Err(Error::Protocol(Kind::ExpectedField(Field::Authzid)));
+    };
+
+    // Authcid
+    let authcid = parse_part!(parts, Authcid, b"n=");
+
+    // Nonce
+    let nonce = match parts.next() {
+        Some(part) if &part.as_bytes()[..2] == b"r=" => &part[2..],
+        _ => {
+            return Err(Error::Protocol(Kind::ExpectedField(Field::Nonce)));
+        }
+    };
+    Ok((authcid, authzid, nonce))
+}
+
+/// Parses the client's final message.  Gives an error if the data was malformed.
+fn parse_client_final(data: &str) -> Result<(&str, &str, &str), Error> {
+    // 6 is the length of the required parts of the message
+    let mut parts = data.split(',');
+    let gs2header = parse_part!(parts, GS2Header, b"c=");
+    let nonce = parse_part!(parts, Nonce, b"r=");
+    let proof = parse_part!(parts, Proof, b"p=");
+    Ok((gs2header, nonce, proof))
+}
+
+impl<P: AuthenticationProvider> ScramServer <P> {
+
+    /// Create a new ScramServer using the given authentication provider
+    pub fn new(provider: P) -> Self {
+        ScramServer {
+            provider: provider,
+        }
+
+    }
+
+
+    /// Handle a challenge message sent by the client to the server.  If the message is well
+    /// formed, and the requested user exists, then this will progress to the next stage of the
+    /// authentication process, [`ServerFirst`](struct.ServerFirst.html).  Otherwise, it will
+    /// return an error
+    pub fn handle_client_first<'a>(&'a self, client_first: &'a str) -> Result<ServerFirst<'a, P>, Error> {
+        let (authcid, authzid, client_nonce) = try!(parse_client_first(client_first));
+        let password_info = if let Some(info) = self.provider.get_password_for(authcid) {
+            info
+        } else {
+            return Err(Error::InvalidUser(authcid.to_string()))
+        };
+        Ok(ServerFirst {
+            client_nonce: client_nonce,
+            authcid: authcid,
+            authzid: authzid,
+            provider: &self.provider,
+            password_info: password_info
+        })
+    }
+
+}
+
+/// Represents the first stage in the authentication process, after the client has
+/// submitted their first message.  This struct is responsible for responding to the message
+pub struct ServerFirst<'a, P: 'a + AuthenticationProvider> {
+    client_nonce: &'a str,
+    authcid: &'a str,
+    authzid: Option<&'a str>,
+    provider: &'a P,
+    password_info: PasswordInfo
+}
+
+impl <'a, P: AuthenticationProvider> ServerFirst<'a, P> {
+
+    /// Create the server's first message in response to the client's first message.
+    /// By default, this method uses [`OsRng`](https://doc.rust-lang.org/rand/rand/os/struct.OsRng.html)
+    /// as its source of randomness for the nonce.  To specify the randomness source, use
+    /// [`server_first_with_rng`](#method.server_first_with_rng).
+    /// This method will return an error when it cannot initialize the OS's randomness source.
+    /// See the documentation on `OsRng` for more.
+     pub fn server_first(self) -> io::Result<(ClientFinal<'a, P>, String)> {
+         Ok(self.server_first_with_rng(&mut try!(OsRng::new())))
+     }
+
+     /// Create the server's first message in response to the client's first message, with the
+     /// given source of randomness used for the server's nonce.  The randomness is assigned here
+     /// instead of universally in [`ScramServer`](struct.ScramServer.html) for increased
+     /// flexibility, and also to keep `ScramServer` immutable.
+    pub fn server_first_with_rng<R: Rng>(self, rng: &mut R) -> (ClientFinal<'a, P>, String) {
+        let range = Range::new(33, 125);
+        let server_nonce: String = (0..NONCE_LENGTH)
+            .map(move |_| {
+                let x: u8 = range.ind_sample(&mut *rng);
+                if x > 43 {
+                    (x + 1) as char
+                } else {
+                    x as char
+                }
+            })
+            .collect();
+        let mut nonce = self.client_nonce.to_string();
+        nonce.push_str(&server_nonce);
+
+        let gs2header: Cow<'static, str> = match self.authzid {
+            Some(authzid) => format!("n,a={},", authzid).into(),
+            None => "n,,".into(),
+        };
+
+        let client_first_bare: Cow<'static, str> = format!("n={},r={}",
+                                                            self.authcid,
+                                                            self.client_nonce).into();
+        let server_first: Cow<'static, str> = format!("r={},s={},i={}",
+                                                      nonce,
+                                                      base64::encode(self.password_info.salt.as_slice()),
+                                                      self.password_info.iterations).into();
+
+        (ClientFinal {
+            hashed_password: self.password_info.hashed_password,
+            nonce: nonce,
+            gs2header: gs2header,
+            client_first_bare: client_first_bare,
+            server_first: server_first.clone(),
+            authcid: self.authcid.into(),
+            authzid: self.authzid.map(|a| a.into()),
+            provider: self.provider
+        }, server_first.into_owned())
+    }
+
+}
+
+/// Represents the stage after the server has generated its first response to the client.  This
+/// struct is responsible for handling the client's final message.
+pub struct ClientFinal<'a, P:'a + AuthenticationProvider> {
+    hashed_password:  Vec<u8>,
+    nonce: String,
+    gs2header: Cow<'static, str>,
+    client_first_bare: Cow<'static, str>,
+    server_first: Cow<'static, str>,
+    authcid: &'a str,
+    authzid: Option<&'a str>,
+    provider: &'a P
+}
+
+impl <'a, P: AuthenticationProvider> ClientFinal<'a, P> {
+
+    /// Handle the final client message.  If the message is not well formed, or the authorization
+    /// header is invalid, then this will return an error.  In all other cases (including when
+    /// authentication or authorization has failed), this will return `Ok` along with a message
+    /// to send the client.  In cases where authentication or authorization has failed, the message
+    /// will contain error information for the client.  To check if authentication and
+    /// authorization have succeeded, use [`get_status()`](struct.ServerFinal.html#method.get_status) on
+    /// the return value.
+    pub fn handle_client_final(self, client_final: &str) -> Result<ServerFinal, Error> {
+        let (gs2header_enc, nonce, proof) = try!(parse_client_final(client_final));
+        if !self.verify_header(gs2header_enc) {
+            return Err(Error::Protocol(Kind::InvalidField(Field::GS2Header)))
+        }
+        if !self.verify_nonce(nonce) {
+            return Err(Error::Protocol(Kind::InvalidField(Field::Nonce)))
+        }
+        if let Some(signature) = try!(self.verify_proof(proof)) {
+            if let Some(authzid) = self.authzid {
+                if self.provider.authorize(self.authcid, authzid) {
+                    Ok((ServerFinal{status: AuthenticationStatus::Authenticated, signature: signature}))
+                } else {
+                    Ok((ServerFinal{status: AuthenticationStatus::NotAuthorized, signature: format!("e=User '{}' not authorized to act as '{}'",self.authcid, authzid)}))
+                }
+            } else {
+                Ok((ServerFinal{status: AuthenticationStatus::Authenticated, signature: signature}))
+            }
+        } else {
+            return Ok((ServerFinal{status: AuthenticationStatus::NotAuthenticated, signature:"e=Invalid Password".to_string()}))
+        }
+
+    }
+
+    /// Checks that the gs2header received from the client is the same as the one we've stored
+    fn verify_header(&self, gs2header: &str) -> bool {
+        let server_gs2header = base64::encode(self.gs2header.as_bytes());
+        server_gs2header == gs2header
+    }
+
+    /// Checks that the client has sent the same nonce
+    fn verify_nonce(&self, nonce: &str) -> bool {
+        nonce == self.nonce
+    }
+
+    /// Checks that the proof from the client matches our saved credentials
+    fn verify_proof(&self, proof: &str) -> Result<Option<String>, Error> {
+        let (client_proof, server_signature): ([u8; SHA256_LEN], Digest) =
+            find_proofs(&self.gs2header,
+                        &self.client_first_bare,
+                        &self.server_first,
+                        self.hashed_password.as_slice(),
+                        &self.nonce);
+        let proof = if let Ok(proof) = base64::decode(proof.as_bytes()) {
+            proof
+        } else {
+            return Err(Error::Protocol(Kind::InvalidField(Field::Proof)))
+        };
+        if proof != client_proof {
+            return Ok(None)
+        }
+
+        let server_signature_string = format!("v={}", base64::encode(server_signature.as_ref()));
+        Ok(Some(server_signature_string))
+
+    }
+}
+
+/// Represents the final stage of authentication, after we have generated the final server message
+/// to send to the client
+pub struct ServerFinal {
+    status: AuthenticationStatus,
+    signature: String
+}
+
+impl ServerFinal {
+    /// Get the [`AuthenticationStatus`](enum.AuthenticationStatus.html) of the exchange.  This
+    /// status can be successful, failed because of invalid authentication or failed because of
+    /// invalid authorization.
+    pub fn server_final(self) -> (AuthenticationStatus, String) {
+        (self.status, self.signature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_client_first, parse_client_final};
+    use super::super::{Error, Kind, Field};
+
+    #[test]
+    fn test_parse_client_first_success() {
+        let (authcid, authzid, nonce) = parse_client_first("n,,n=user,r=abcdefghijk").unwrap();
+        assert_eq!(authcid, "user");
+        assert!(authzid.is_none());
+        assert_eq!(nonce, "abcdefghijk");
+
+        let (authcid, authzid, nonce) = parse_client_first("y,a=other user,n=user,r=abcdef=hijk").unwrap();
+        assert_eq!(authcid, "user");
+        assert_eq!(authzid, Some("other user"));
+        assert_eq!(nonce, "abcdef=hijk");
+
+        let (authcid, authzid, nonce) = parse_client_first("n,,n=,r=").unwrap();
+        assert_eq!(authcid, "");
+        assert!(authzid.is_none());
+        assert_eq!(nonce, "");
+    }
+
+    #[test]
+    fn test_parse_client_first_missing_fields() {
+        assert_eq!(parse_client_first("n,,n=user").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Nonce)));
+        assert_eq!(parse_client_first("n,,r=user").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Authcid)));
+        assert_eq!(parse_client_first("n,n=user,r=abc").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Authzid)));
+        assert_eq!(parse_client_first(",,n=user,r=abc").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::ChannelBinding)));
+        assert_eq!(parse_client_first("").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::ChannelBinding)));
+        assert_eq!(parse_client_first(",,,").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::ChannelBinding)));
+    }
+    #[test]
+    fn test_parse_client_first_invalid_data() {
+        assert_eq!(parse_client_first("a,,n=user,r=abc").unwrap_err(), Error::Protocol(Kind::InvalidField(Field::ChannelBinding)));
+        assert_eq!(parse_client_first("p,,n=user,r=abc").unwrap_err(), Error::UnsupportedExtension);
+        assert_eq!(parse_client_first("nn,,n=user,r=abc").unwrap_err(), Error::Protocol(Kind::InvalidField(Field::ChannelBinding)));
+        assert_eq!(parse_client_first("n,,n,r=abc").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Authcid)));
+    }
+
+    #[test]
+    fn test_parse_client_final_success() {
+        let (gs2head, nonce, proof) = parse_client_final("c=abc,r=abcefg,p=783232").unwrap();
+        assert_eq!(gs2head, "abc");
+        assert_eq!(nonce, "abcefg");
+        assert_eq!(proof, "783232");
+
+        let (gs2head, nonce, proof) = parse_client_final("c=,r=,p=").unwrap();
+        assert_eq!(gs2head, "");
+        assert_eq!(nonce, "");
+        assert_eq!(proof, "");
+    }
+
+    #[test]
+    fn test_parse_client_final_missing_fields() {
+        assert_eq!(parse_client_final("c=whatever,r=something").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Proof)));
+        assert_eq!(parse_client_final("c=whatever,p=words").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Nonce)));
+        assert_eq!(parse_client_final("c=whatever").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Nonce)));
+        assert_eq!(parse_client_final("c=").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::Nonce)));
+        assert_eq!(parse_client_final("").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::GS2Header)));
+        assert_eq!(parse_client_final("r=anonce").unwrap_err(), Error::Protocol(Kind::ExpectedField(Field::GS2Header)));
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,78 @@
+use std::borrow::Cow;
+use data_encoding::base64;
+use ring::digest::{digest, SHA256, Digest};
+use ring::hmac::{SigningKey, SigningContext, sign};
+use ring::pbkdf2::{HMAC_SHA256, derive};
+use ::{SHA256_LEN};
+
+/// Parses a part of a SCRAM message, after it has been split on commas.
+/// Checks to make sure there's a key, and then verifies its the right key.
+/// Returns everything after the first '='.
+/// Returns a ExpectedField error when one of the above conditions fails.
+macro_rules! parse_part {
+    ($iter: expr, $field: ident, $key: expr) => (
+        if let Some(part) = $iter.next() {
+            if part.len() < 2 {
+                return Err(Error::Protocol(Kind::ExpectedField(Field::$field)));
+            } else if &part.as_bytes()[..2] == $key {
+                &part[2..]
+            } else {
+                return Err(Error::Protocol(Kind::ExpectedField(Field::$field)));
+            }
+        } else {
+            return Err(Error::Protocol(Kind::ExpectedField(Field::$field)));
+        }
+
+    );
+}
+
+/// Hashes a password with SHA-256 with the given salt and number of iterations.  This should
+/// be used by [`AuthenticationProvider`](server/trait.AuthenticationProvider.html) implementors
+/// to hash any passwords prior to being saved.
+pub fn hash_password(password: &str, iterations: u16, salt: &[u8]) -> [u8; SHA256_LEN] {
+    let mut salted_password = [0u8; SHA256_LEN];
+    derive(&HMAC_SHA256,
+           iterations as usize,
+           salt,
+           password.as_bytes(),
+           &mut salted_password);
+    salted_password
+}
+
+/// Finds the client proof and server signature based on the shared hashed key.
+pub fn find_proofs(gs2header: &Cow<'static, str>, client_first_bare: &Cow<str>, server_first: &Cow<str>, salted_password: &[u8], nonce: &str) -> ([u8;SHA256_LEN], Digest) {
+    fn sign_slice(key: &SigningKey, slice: &[&[u8]]) -> Digest {
+        let mut signature_context = SigningContext::with_key(key);
+        for item in slice {
+            signature_context.update(item);
+        }
+        signature_context.sign()
+    }
+
+    let client_final_without_proof = format!("c={},r={}",
+                                             base64::encode(gs2header.as_bytes()),
+                                             nonce);
+    let auth_message = [client_first_bare.as_bytes(),
+                        b",",
+                        server_first.as_bytes(),
+                        b",",
+                        client_final_without_proof.as_bytes()];
+
+
+
+    let salted_password_signing_key = SigningKey::new(&SHA256, salted_password);
+    let client_key = sign(&salted_password_signing_key, b"Client Key");
+    let server_key = sign(&salted_password_signing_key, b"Server Key");
+    let stored_key = digest(&SHA256, client_key.as_ref());
+    let stored_key_signing_key = SigningKey::new(&SHA256, stored_key.as_ref());
+    let client_signature = sign_slice(&stored_key_signing_key, &auth_message);
+    let server_signature_signing_key = SigningKey::new(&SHA256, server_key.as_ref());
+    let server_signature = sign_slice(&server_signature_signing_key, &auth_message);
+    let mut client_proof = [0u8; SHA256_LEN];
+    let xor_iter =
+        client_key.as_ref().iter().zip(client_signature.as_ref()).map(|(k, s)| k ^ s);
+    for (p, x) in client_proof.iter_mut().zip(xor_iter) {
+        *p = x
+    }
+    (client_proof, server_signature)
+}

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -1,0 +1,185 @@
+extern crate scram;
+extern crate rand;
+
+use scram::*;
+
+const SHA256_LEN: usize = 32;
+
+struct TestProvider {
+    user_password: [u8; SHA256_LEN],
+    admin_password: [u8; SHA256_LEN]
+}
+
+impl TestProvider {
+    pub fn new() -> Self {
+        let user_password = hash_password("password", 4096, "salt".as_bytes());
+        let admin_password = hash_password("admin_password", 8192, "messy".as_bytes());
+        TestProvider {
+            user_password: user_password,
+            admin_password: admin_password
+        }
+    }
+}
+
+impl server::AuthenticationProvider for TestProvider {
+    fn get_password_for(&self, username: &str) -> Option<server::PasswordInfo> {
+        match username {
+            "user" => Some(server::PasswordInfo::new(self.user_password.to_vec(), 4096, "salt".bytes().collect())),
+            "admin" => Some(server::PasswordInfo::new(self.admin_password.to_vec(), 8192, "messy".bytes().collect())),
+            _ => None
+        }
+    }
+
+    fn authorize(&self, authcid: &str, authzid: &str) -> bool {
+        authcid == authzid || authcid == "admin" && authzid =="user"
+    }
+}
+
+
+#[test]
+fn test_simple_success() {
+
+    let scram_client = client::ClientFirst::new("user", "password", None).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (scram_client, client_first) = scram_client.client_first();
+
+    let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+    let (scram_server, server_first) = scram_server.server_first().unwrap();
+
+    let scram_client = scram_client.handle_server_first(&server_first).unwrap();
+    let (scram_client, client_final) = scram_client.client_final();
+
+    let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+    let(status, server_final) = scram_server.server_final();
+
+
+    scram_client.handle_server_final(&server_final).unwrap();
+
+    assert_eq!(status, server::AuthenticationStatus::Authenticated);
+}
+
+#[test]
+fn test_bad_password() {
+    let scram_client = client::ClientFirst::new("user", "badpassword", None).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (scram_client, client_first) = scram_client.client_first();
+
+    let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+    let (scram_server, server_first) = scram_server.server_first().unwrap();
+
+    let scram_client = scram_client.handle_server_first(&server_first).unwrap();
+    let (scram_client, client_final) = scram_client.client_final();
+
+    let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+    let(status, server_final) = scram_server.server_final();
+
+    assert_eq!(status, server::AuthenticationStatus::NotAuthenticated);
+    assert!(scram_client.handle_server_final(&server_final).is_err());
+}
+
+#[test]
+fn test_authorize_different() {
+    let scram_client = client::ClientFirst::new("admin", "admin_password", Some("user")).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (scram_client, client_first) = scram_client.client_first();
+
+    let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+    let (scram_server, server_first) = scram_server.server_first().unwrap();
+
+    let scram_client = scram_client.handle_server_first(&server_first).unwrap();
+    let (scram_client, client_final) = scram_client.client_final();
+
+    let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+    let(status, server_final) = scram_server.server_final();
+
+    scram_client.handle_server_final(&server_final).unwrap();
+
+    assert_eq!(status, server::AuthenticationStatus::Authenticated);
+}
+
+#[test]
+fn test_authorize_fail() {
+    let scram_client = client::ClientFirst::new("user", "password", Some("admin")).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (scram_client, client_first) = scram_client.client_first();
+
+    let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+    let (scram_server, server_first) = scram_server.server_first().unwrap();
+
+    let scram_client = scram_client.handle_server_first(&server_first).unwrap();
+    let (scram_client, client_final) = scram_client.client_final();
+
+    let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+    let(status, server_final) = scram_server.server_final();
+
+
+    assert_eq!(status, server::AuthenticationStatus::NotAuthorized);
+    assert!(scram_client.handle_server_final(&server_final).is_err());
+}
+
+#[test]
+fn test_authorize_non_existent() {
+    let scram_client = client::ClientFirst::new("admin", "admin_password", Some("nonexistent")).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (scram_client, client_first) = scram_client.client_first();
+
+    let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+    let (scram_server, server_first) = scram_server.server_first().unwrap();
+
+    let scram_client = scram_client.handle_server_first(&server_first).unwrap();
+    let (scram_client, client_final) = scram_client.client_final();
+
+    let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+    let(status, server_final) = scram_server.server_final();
+
+
+    assert_eq!(status, server::AuthenticationStatus::NotAuthorized);
+    assert!(scram_client.handle_server_final(&server_final).is_err());
+}
+
+#[test]
+fn test_invalid_user() {
+
+    let scram_client = client::ClientFirst::new("nobody", "password", None).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (_, client_first) = scram_client.client_first();
+
+    assert!(scram_server.handle_client_first(&client_first).is_err())
+}
+
+#[test]
+fn test_empty_username() {
+
+    let scram_client = client::ClientFirst::new("", "password", None).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (_, client_first) = scram_client.client_first();
+
+    assert!(scram_server.handle_client_first(&client_first).is_err())
+}
+
+#[test]
+fn test_empty_password() {
+    let scram_client = client::ClientFirst::new("user", "", None).unwrap();
+    let scram_server = server::ScramServer::new(TestProvider::new());
+
+    let (scram_client, client_first) = scram_client.client_first();
+
+    let scram_server = scram_server.handle_client_first(&client_first).unwrap();
+    let (scram_server, server_first) = scram_server.server_first().unwrap();
+
+    let scram_client = scram_client.handle_server_first(&server_first).unwrap();
+    let (scram_client, client_final) = scram_client.client_final();
+
+    let scram_server = scram_server.handle_client_final(&client_final).unwrap();
+    let(status, server_final) = scram_server.server_final();
+
+    assert_eq!(status, server::AuthenticationStatus::NotAuthenticated);
+    assert!(scram_client.handle_server_final(&server_final).is_err());
+}


### PR DESCRIPTION
As the message says, I implemented a SCRAM server that uses a trait to provide password information.

I did end up modifying a little bit of the client code, but only to move some code that I was also using to a utils module.

I think I've followed the pattern established in the client module pretty well, and I've updated the documentation to reflect how the server works.  I also added some tests in `tests/client_server.rs` that verify they work properly together.

I'm happy to adjust anything you like, or explain any decisions I made.