### PR TITLE
0.2.0: Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ name = "scram"
 repository = "https://github.com/tomprogrammer/scram"
 documentation = "https://tomprogrammer.github.io/scram/scram/index.html"
 readme = "README.md"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]
 data-encoding = "1.1"
 rand = "0.3"
-ring = "0.6"
+ring = "0.9.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use rand::distributions::IndependentSample;
 use rand::distributions::range::Range;
 use rand::os::OsRng;
 use rand::Rng;
-use ring::digest::Digest;
+use ring::hmac;
 
 use utils::{hash_password, find_proofs};
 use error::{Error, Kind, Field};
@@ -179,7 +179,7 @@ impl<'a> ServerFirst<'a> {
 
         let salted_password = hash_password(self.password, iterations, &salt);
 
-        let (client_proof, server_signature): ([u8; SHA256_LEN], Digest) =
+        let (client_proof, server_signature): ([u8; SHA256_LEN], hmac::Signature) =
             find_proofs(&self.gs2header,
                         &self.client_first_bare.into(),
                         &server_first.into(),
@@ -201,7 +201,7 @@ impl<'a> ServerFirst<'a> {
 /// processed.
 #[derive(Debug)]
 pub struct ClientFinal {
-    server_signature: Digest,
+    server_signature: hmac::Signature,
     client_final: String,
 }
 
@@ -221,7 +221,7 @@ impl ClientFinal {
 /// The final state of the SCRAM mechanism after the final client message was computed.
 #[derive(Debug)]
 pub struct ServerFinal {
-    server_signature: Digest,
+    server_signature: hmac::Signature,
 }
 
 impl ServerFinal {

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use rand::distributions::IndependentSample;
 use rand::distributions::range::Range;
 use rand::os::OsRng;
 use rand::Rng;
-use ring::digest::Digest;
+use ring::hmac;
 
 use error::{Error, Kind, Field};
 use utils::find_proofs;
@@ -293,7 +293,7 @@ impl <'a, P: AuthenticationProvider> ClientFinal<'a, P> {
 
     /// Checks that the proof from the client matches our saved credentials
     fn verify_proof(&self, proof: &str) -> Result<Option<String>, Error> {
-        let (client_proof, server_signature): ([u8; SHA256_LEN], Digest) =
+        let (client_proof, server_signature): ([u8; SHA256_LEN], hmac::Signature) =
             find_proofs(&self.gs2header,
                         &self.client_first_bare,
                         &self.server_first,


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another dependend on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make the scram crate easier to update to 0.9.x.

Incidentally, I think that scram's usage of *ring* is a good example of why it was a good idea to introduce the `hmac::Signature` type.