### PR TITLE
Downgrade `ring` to `v0.12.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license = "MIT"
 name = "scram"
 readme = "README.md"
 repository = "https://github.com/tomprogrammer/scram"
-version = "0.2.3"
+version = "0.2.4"
 
 [dependencies]
 base64 = "0.9.0"
 rand = "0.4.2"
-ring = "0.13.0-alpha"
+ring = "0.12.1"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,9 @@
-Version 0.2.2 (2018-01-09)
+Version 0.2.4 (2018-05-02)
+==========================
+
+* Downgrade `ring` to version `0.12.1` as per recommendation from its author.
+
+Version 0.2.3 (2018-01-09)
 ==========================
 
 * Update `ring` to version `0.13.0-alpha` since previous versions fail to build.


### PR DESCRIPTION
As per recommendation from [Brian].

[Brian]: https://twitter.com/BRIAN_____/status/955339612381093888

/cc @tomprogrammer 