### PR TITLE
Added support for ring 0.16.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT"
 name = "scram"
 readme = "README.md"
 repository = "https://github.com/tomprogrammer/scram"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 base64 = "0.10.0"
 rand = "0.5.0"
-ring = "0.13"
+ring = "0.16.9"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/server.rs
+++ b/src/server.rs
@@ -292,14 +292,13 @@ impl<'a, P: AuthenticationProvider> ClientFinal<'a, P> {
 
     /// Checks that the proof from the client matches our saved credentials
     fn verify_proof(&self, proof: &str) -> Result<Option<String>, Error> {
-        let (client_proof, server_signature): ([u8; SHA256_OUTPUT_LEN], hmac::Signature) =
-            find_proofs(
-                &self.gs2header,
-                &self.client_first_bare,
-                &self.server_first,
-                self.hashed_password.as_slice(),
-                &self.nonce,
-            );
+        let (client_proof, server_signature): ([u8; SHA256_OUTPUT_LEN], hmac::Tag) = find_proofs(
+            &self.gs2header,
+            &self.client_first_bare,
+            &self.server_first,
+            self.hashed_password.as_slice(),
+            &self.nonce,
+        );
         let proof = if let Ok(proof) = base64::decode(proof.as_bytes()) {
             proof
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,7 @@
 use base64;
-use ring::digest;
-use ring::digest::{digest, SHA256_OUTPUT_LEN};
+use ring::digest::{self, digest, SHA256_OUTPUT_LEN};
 use ring::hmac::{self, Context, Key, HMAC_SHA256};
-use ring::pbkdf2;
-use ring::pbkdf2::PBKDF2_HMAC_SHA256 as SHA256;
+use ring::pbkdf2::{self, PBKDF2_HMAC_SHA256 as SHA256};
 use std::num::{NonZeroU16, NonZeroU32};
 
 /// Parses a part of a SCRAM message, after it has been split on commas.

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -4,6 +4,7 @@ extern crate scram;
 
 use ring::digest::SHA256_OUTPUT_LEN;
 use scram::*;
+use std::num::NonZeroU16;
 
 struct TestProvider {
     user_password: [u8; SHA256_OUTPUT_LEN],
@@ -12,8 +13,10 @@ struct TestProvider {
 
 impl TestProvider {
     pub fn new() -> Self {
-        let user_password = hash_password("password", 4096, b"salt");
-        let admin_password = hash_password("admin_password", 8192, b"messy");
+        let pwd_iterations = NonZeroU16::new(4096).unwrap();
+        let user_password = hash_password("password", pwd_iterations, b"salt");
+        let adm_iterations = NonZeroU16::new(8192).unwrap();
+        let admin_password = hash_password("admin_password", adm_iterations, b"messy");
         TestProvider {
             user_password: user_password,
             admin_password: admin_password,


### PR DESCRIPTION
In my current project, I'm using the "reql" crate and the "jsonwebtoken" crate. The "reql" crate depends on "scram" which depends on "ring". The version of "ring" that "jsonwebtoken" requires, is a breaking change newer than what is currently supported by "scram" and has produced a conflict. This change implements the new API of the "ring" crate.