### PR TITLE
Update base64 and rand dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/tomprogrammer/scram"
 version = "0.5.0"
 
 [dependencies]
-base64 = "0.11.0"
-rand = "0.7.0"
+base64 = "0.13.0"
+rand = "0.8.0"
 ring = "0.16.9"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "scram"
 readme = "README.md"
 repository = "https://github.com/tomprogrammer/scram"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 base64 = "0.13.0"


### PR DESCRIPTION
In the meanwhile, `base64` has been updated to `0.13` and `rand` moved to `0.8`