### PR TITLE
Make authcid,authzid,client_nonce readable from server side

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "scram"
 readme = "README.md"
 repository = "https://github.com/tomprogrammer/scram"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 base64 = "0.13.0"

--- a/src/server.rs
+++ b/src/server.rs
@@ -213,6 +213,21 @@ impl<'a, P: AuthenticationProvider> ServerFirst<'a, P> {
             server_first.into_owned(),
         )
     }
+
+    /// The username parsed from client first message that used for authentication.
+    pub fn authcid(&self) -> &str {
+        self.authcid
+    }
+
+    /// The username parsed from client first message that used for authorization.
+    pub fn authzid(&self) -> Option<&str> {
+        self.authzid
+    }
+
+    /// The nonce value parsed from client first message.
+    pub fn client_nonce(&self) -> &str {
+        self.client_nonce
+    }
 }
 
 /// Represents the stage after the server has generated its first response to the client. This
@@ -271,6 +286,16 @@ impl<'a, P: AuthenticationProvider> ClientFinal<'a, P> {
                 signature: "e=Invalid Password".to_string(),
             })
         }
+    }
+
+    /// The username parsed from client first message that used for authentication.
+    pub fn authcid(&self) -> &str {
+        self.authcid
+    }
+
+    /// The username parsed from client first message that used for authorization.
+    pub fn authzid(&self) -> Option<&str> {
+        self.authzid
     }
 
     /// Checks that the gs2header received from the client is the same as the one we've stored


### PR DESCRIPTION
### Changes
* Add functions to make below fields readable:
  - `ServerFirst.client_nonce`
  - `ServerFirst.authcid`
  - `ServerFirst.authzid`
  - `ClientFinal.authcid`
  - `ClientFinal.authzid`
* Bump version from `0.6.0` to `0.6.1`

Fix issue #16 